### PR TITLE
Fix config check bug

### DIFF
--- a/src/Our.Umbraco.GMaps.Core/App_Plugins/Our.Umbraco.GMaps/js/our.umbraco.gmaps.controller.js
+++ b/src/Our.Umbraco.GMaps.Core/App_Plugins/Our.Umbraco.GMaps/js/our.umbraco.gmaps.controller.js
@@ -30,7 +30,7 @@
                 if ($scope.model.config.zoom !== null) {
                     $scope.defaultZoom = $scope.model.config.zoom;
                 }
-                if ($scope.model.config.zoom !== null) {
+                if ($scope.model.config.apikey !== null) {
                     $scope.apiKey = $scope.model.config.apikey;
                 }
             }


### PR DESCRIPTION
When setting api key from config it was checking the zoom level for null instead of the api key