### PR TITLE
Split nuget into two so core dll can be installed without extra fields

### DIFF
--- a/src/Our.Umbraco.GMaps.Core/Our.Umbraco.GMaps.Complete.nuspec
+++ b/src/Our.Umbraco.GMaps.Core/Our.Umbraco.GMaps.Complete.nuspec
@@ -1,0 +1,31 @@
+<?xml version="1.0"?>
+<package >
+  <metadata>
+    <id>Our.Umbraco.GMaps</id>
+    <version>1.2.0</version>
+    <title>Our.Umbraco.GMaps - Google Maps for Umbraco 8</title>
+    <authors>Arnold Visser</authors>
+    <owners>Arnold Visser</owners>
+    <license type="expression">MIT</license>
+    <projectUrl>https://github.com/ArnoldV/Our.Umbraco.GMaps</projectUrl>
+    <iconUrl>https://github.com/ArnoldV/Our.Umbraco.GMaps/blob/master/images/logo.jpg?raw=true</iconUrl>
+    <requireLicenseAcceptance>false</requireLicenseAcceptance>
+    <description>Basic Google Maps with autocomplete property editor for Umbraco 8</description>
+    <releaseNotes>
+      - [NEW] Set mapstyles using your SnazzyMaps API key!
+      - [NEW] Set mapstyles using JSON
+      - bugfixes
+    </releaseNotes>
+    <copyright>Copyright 2019</copyright>
+    <tags>Umbraco Property Editor Google Maps</tags>
+    
+    <dependencies>
+        <dependency id="UmbracoCms" version="8.1.0" />
+        <dependency id="Our.Umbraco.GMaps.Core" version="1.2.0" />
+    </dependencies>
+  </metadata>
+  <files>
+    <file src="App_Plugins\Our.Umbraco.GMaps\**\*.*" target="content\App_Plugins\Our.Umbraco.GMaps" />
+	  <file src="readme.txt" target="" />
+  </files>
+</package>

--- a/src/Our.Umbraco.GMaps.Core/Our.Umbraco.GMaps.Core.csproj
+++ b/src/Our.Umbraco.GMaps.Core/Our.Umbraco.GMaps.Core.csproj
@@ -244,6 +244,7 @@
     <None Include="app.config" />
     <None Include="App_Plugins\Our.Umbraco.GMaps\package.manifest" />
     <None Include="Our.Umbraco.GMaps.Core.nuspec" />
+    <None Include="Our.Umbraco.GMaps.Complete.nuspec" />
     <None Include="packages.config" />
     <Content Include="Views\Partials\Our.Umbraco.GMaps\MapScripts.cshtml" />
   </ItemGroup>


### PR DESCRIPTION
Splitting nuget into two, current one stays as the main one but has a dependency on the new Core package.
NuSpec file .Complete builds the main package.
Building against the csproj only builds the new .Core project now.

This is in response to #8 
Would need a new Nuget entry on Nuget.Org to make available :-)