### PR TITLE
Replace element IDs with class selectors.

### DIFF
--- a/src/Our.Umbraco.GMaps.Web/App_Plugins/Our.Umbraco.GMaps/js/our.umbraco.gmaps.controller.js
+++ b/src/Our.Umbraco.GMaps.Web/App_Plugins/Our.Umbraco.GMaps/js/our.umbraco.gmaps.controller.js
@@ -1,9 +1,10 @@
 ﻿angular.module("umbraco").controller("Our.Gmaps.Core.Controller",
     [
         "$scope",
+        "$element",
         "OurGmapsCoreFactory",
 
-        function ($scope, OurGmapsCoreFactory) {
+        function ($scope, $element, OurGmapsCoreFactory) {
             'use strict';
 
             $scope.apiKey = '';
@@ -23,8 +24,8 @@
             $scope.showLoader = true;
             $scope.searchedValue = '';
 
-            var mapElement = document.getElementById('map-canvas');
-            var autoCompleteElement = document.getElementById('map-autocomplete');
+            var mapElement = $element.find('.our-coremaps__canvas').get(0);
+            var autoCompleteElement = $element.find('.our-coremaps__autocomplete').get(0);
 
             if ($scope.model.config !== null) {
                 // default location when set on data type config

--- a/src/Our.Umbraco.GMaps/App_Plugins/Our.Umbraco.GMaps/js/our.umbraco.gmaps.controller.js
+++ b/src/Our.Umbraco.GMaps/App_Plugins/Our.Umbraco.GMaps/js/our.umbraco.gmaps.controller.js
@@ -1,9 +1,10 @@
 ﻿angular.module("umbraco").controller("Our.Gmaps.Core.Controller",
     [
         "$scope",
+        "$element",
         "OurGmapsCoreFactory",
 
-        function ($scope, OurGmapsCoreFactory) {
+        function ($scope, $element, OurGmapsCoreFactory) {
             'use strict';
 
             $scope.apiKey = '';
@@ -23,8 +24,8 @@
             $scope.showLoader = true;
             $scope.searchedValue = '';
 
-            var mapElement = document.getElementById('map-canvas');
-            var autoCompleteElement = document.getElementById('map-autocomplete');
+            var mapElement = $element.find('.our-coremaps__canvas').get(0);
+            var autoCompleteElement = $element.find('.our-coremaps__autocomplete').get(0);
 
             if ($scope.model.config !== null) {
                 // default location when set on data type config

--- a/src/Our.Umbraco.GMaps/App_Plugins/Our.Umbraco.GMaps/views/our.umbraco.gmaps.editor.html
+++ b/src/Our.Umbraco.GMaps/App_Plugins/Our.Umbraco.GMaps/views/our.umbraco.gmaps.editor.html
@@ -7,7 +7,7 @@
         margin-bottom: 20px;
     }
 
-    .our-coremaps--loading #map-canvas::after {
+    .our-coremaps--loading .our-coremaps__canvas::after {
         content: '';
         top: 0;
         left: 0;
@@ -17,7 +17,7 @@
         background: rgba(246, 244, 244, 0.75);
     }
 
-    #map-canvas {
+    .our-coremaps__canvas {
         position: relative;
         height: 500px;
         width: 100%;

--- a/src/Our.Umbraco.GMaps/App_Plugins/Our.Umbraco.GMaps/views/our.umbraco.gmaps.editor.html
+++ b/src/Our.Umbraco.GMaps/App_Plugins/Our.Umbraco.GMaps/views/our.umbraco.gmaps.editor.html
@@ -28,10 +28,10 @@
 <div class="our-coremaps" ng-class="{'our-coremaps--loading': showLoader}" ng-controller="Our.Gmaps.Core.Controller as vm">
 
     <div class="our-coremaps__area">        
-        <input type="text" id="map-autocomplete" class="umb-property-editor umb-textstring textstring" placeholder="Type name, address or geolocation" ng-model="searchedValue" />
+        <input type="text" class="our-coremaps__autocomplete umb-property-editor umb-textstring textstring" placeholder="Type name, address or geolocation" ng-model="searchedValue" />
     </div>
 
-    <div id="map-canvas"></div>
+    <div class="our-coremaps__canvas"></div>
 
     <umb-load-indicator ng-show="showLoader">
     </umb-load-indicator>


### PR DESCRIPTION
This PR replace the element ID attributes with CSS class selectors to allow multiple map fields to be used on the same page (which currently is logged in issue #13).