### PR TITLE
Fix #22 by increasing z-index of places autocomplete popup to 10000

### DIFF
--- a/src/Our.Umbraco.GMaps/App_Plugins/Our.Umbraco.GMaps/views/our.umbraco.gmaps.editor.html
+++ b/src/Our.Umbraco.GMaps/App_Plugins/Our.Umbraco.GMaps/views/our.umbraco.gmaps.editor.html
@@ -23,6 +23,11 @@
         width: 100%;
         margin-bottom: 20px;
     }
+
+    /*Fix z-index of Google Places Autocomplete popup, which will otherwise be hidden*/
+    .pac-container {
+        z-index: 10000 !important;
+    }
 </style>
 
 <div class="our-coremaps" ng-class="{'our-coremaps--loading': showLoader}" ng-controller="Our.Gmaps.Core.Controller as vm">


### PR DESCRIPTION
This PR fixes #22 by increasing the z-index of the popup to 10000 to allow it to be usable in places like the new Block List Editor