### PR TITLE
Add gestureHandling: "cooperative"

### DIFF
--- a/src/Our.Umbraco.GMaps/App_Plugins/Our.Umbraco.GMaps/js/our.umbraco.gmaps.controller.js
+++ b/src/Our.Umbraco.GMaps/App_Plugins/Our.Umbraco.GMaps/js/our.umbraco.gmaps.controller.js
@@ -297,6 +297,7 @@
                 var mapOptions = {
                     zoom: $scope.zoomLevel,
                     center: latLng,
+                    gestureHandling: "cooperative",
                     mapTypeControlOptions: {
                         mapTypeIds: maptypeIds
                     }


### PR DESCRIPTION
Add gestureHandling: "cooperative", so that scrolling in the back-office doesn't inadvertently move the map?