### PR TITLE
Fixes bug in version fallback handling.

### DIFF
--- a/Our.Umbraco.GMaps/App_Plugins/Our.Umbraco.GMaps/js/maps.controller.js
+++ b/Our.Umbraco.GMaps/App_Plugins/Our.Umbraco.GMaps/js/maps.controller.js
@@ -357,7 +357,7 @@ angular.module('umbraco').controller('GMapsMapsController', ['$scope', '$element
 					if ($scope.model.value.address.coordinates) {
 						$scope.address.coordinates = $scope.model.value.address.coordinates
 						enableSearchedCoordinates = true
-					} else if (vm.model.value.address.latlng) {
+					} else if ($scope.model.value.address.latlng) {
 						// Fall back to legacy field.
 						$scope.address.coordinates = parseCoordinates($scope.model.value.address.latlng)
 						enableSearchedCoordinates = true


### PR DESCRIPTION
I discovered this minor overlook when trying to upgrade in a site currently using version 1.3.3.  
All existing values throw an exception when trying to read that "train".  
As far as I can see, the model has not (or is never?) assigned to the vm instance.  
This fixed our install.