### PR TITLE
Better V8 -> V9 compatibility

### DIFF
--- a/Our.Umbraco.GMaps.Core/Models/Address.cs
+++ b/Our.Umbraco.GMaps.Core/Models/Address.cs
@@ -5,6 +5,11 @@ namespace Our.Umbraco.GMaps.Models
 {
     public class Address
     {
+        //Legacy property for V8 data
+        [DataMember(Name = "latlng")]
+        [JsonProperty("latlng")]
+        public string Latlng { get; set; }
+        
         [DataMember(Name = "coordinates")]
         [JsonProperty("coordinates")]
         public Location Coordinates { get; set; }

--- a/Our.Umbraco.GMaps.Core/Models/Location.cs
+++ b/Our.Umbraco.GMaps.Core/Models/Location.cs
@@ -10,34 +10,31 @@ namespace Our.Umbraco.GMaps.Models
 
         [DataMember(Name = "lat")]
         [JsonProperty("lat")]
-        public double Latitude { get; set; }
+        public string Latitude { get; set; }
 
         [DataMember(Name = "lng")]
         [JsonProperty("lng")]
-        public double Longitude { get; set; }
+        public string Longitude { get; set; }
 
-        public bool IsEmpty => Latitude == 0 && Longitude == 0;
+        public bool IsEmpty => Latitude == String.Empty && Longitude == String.Empty;
 
         /// <summary>
         /// Parse the coordinates string.
         /// </summary>
         /// <param name="latLng"></param>
         /// <returns></returns>
-        internal static Location Parse(string latLng)
+         internal static Location Parse(string latlng)
         {
-            if (!string.IsNullOrEmpty(latLng))
+            if (!string.IsNullOrEmpty(latlng))
             {
-                var pair = latLng.Split(new[] { ',' }, StringSplitOptions.RemoveEmptyEntries);
+                var pair = latlng.Split(new[] { ',' }, StringSplitOptions.RemoveEmptyEntries);
                 if (pair.Length == 2)
                 {
-                    if (double.TryParse(pair[0], out double latitude) && double.TryParse(pair[1], out double longitude))
+                    return new Location
                     {
-                        return new Location
-                        {
-                            Latitude = latitude,
-                            Longitude = longitude
-                        };
-                    }
+                        Latitude = pair[0],
+                        Longitude = pair[1]
+                    };
                 }
             }
             return new Location();

--- a/Our.Umbraco.GMaps.Core/Models/Location.cs
+++ b/Our.Umbraco.GMaps.Core/Models/Location.cs
@@ -1,5 +1,6 @@
-﻿using Newtonsoft.Json;
+using Newtonsoft.Json;
 using System;
+using System.Globalization;
 using System.Runtime.Serialization;
 
 namespace Our.Umbraco.GMaps.Models
@@ -10,31 +11,34 @@ namespace Our.Umbraco.GMaps.Models
 
         [DataMember(Name = "lat")]
         [JsonProperty("lat")]
-        public string Latitude { get; set; }
+        public double Latitude { get; set; }
 
         [DataMember(Name = "lng")]
         [JsonProperty("lng")]
-        public string Longitude { get; set; }
+        public double Longitude { get; set; }
 
-        public bool IsEmpty => Latitude == String.Empty && Longitude == String.Empty;
+        public bool IsEmpty => Latitude == 0 && Longitude == 0;
 
         /// <summary>
         /// Parse the coordinates string.
         /// </summary>
-        /// <param name="latLng"></param>
+        /// <param name="latlng"></param>
         /// <returns></returns>
-         internal static Location Parse(string latlng)
+        internal static Location Parse(string latlng)
         {
             if (!string.IsNullOrEmpty(latlng))
             {
                 var pair = latlng.Split(new[] { ',' }, StringSplitOptions.RemoveEmptyEntries);
                 if (pair.Length == 2)
                 {
-                    return new Location
+                    if (double.TryParse(pair[0], NumberStyles.Any, CultureInfo.InvariantCulture, out double latitude) && double.TryParse(pair[1], NumberStyles.Any, CultureInfo.InvariantCulture, out double longitude))
                     {
-                        Latitude = pair[0],
-                        Longitude = pair[1]
-                    };
+                        return new Location
+                        {
+                            Latitude = latitude,
+                            Longitude = longitude
+                        };
+                    }
                 }
             }
             return new Location();

--- a/Our.Umbraco.GMaps.Core/Models/Location.cs
+++ b/Our.Umbraco.GMaps.Core/Models/Location.cs
@@ -22,13 +22,13 @@ namespace Our.Umbraco.GMaps.Models
         /// <summary>
         /// Parse the coordinates string.
         /// </summary>
-        /// <param name="latlng"></param>
+        /// <param name="latLng"></param>
         /// <returns></returns>
-        internal static Location Parse(string latlng)
+        internal static Location Parse(string latLng)
         {
-            if (!string.IsNullOrEmpty(latlng))
+            if (!string.IsNullOrEmpty(latLng))
             {
-                var pair = latlng.Split(new[] { ',' }, StringSplitOptions.RemoveEmptyEntries);
+                var pair = latLng.Split(new[] { ',' }, StringSplitOptions.RemoveEmptyEntries);
                 if (pair.Length == 2)
                 {
                     if (double.TryParse(pair[0], NumberStyles.Any, CultureInfo.InvariantCulture, out double latitude) && double.TryParse(pair[1], NumberStyles.Any, CultureInfo.InvariantCulture, out double longitude))

--- a/Our.Umbraco.GMaps.Core/PropertyValueConverter/SingleMapPropertyValueConverter.cs
+++ b/Our.Umbraco.GMaps.Core/PropertyValueConverter/SingleMapPropertyValueConverter.cs
@@ -36,7 +36,16 @@ namespace Our.Umbraco.GMaps.PropertyValueConverter
 
             if (inter != null)
             {
+                //V8 data has extra content for MapType, strip it if it exists.
+                inter = inter.ToString().Replace("google.maps.MapTypeId.", string.Empty);
+
                 model = JsonConvert.DeserializeObject<Map>(inter.ToString());
+                
+                //if its V8 data, convert it to Location object
+                if (!string.IsNullOrWhiteSpace(model.Address?.Latlng))
+                {
+                    model.Address.Coordinates = Location.Parse(model.Address.Latlng);
+                }
             }
 
             if (model != null)


### PR DESCRIPTION
Readded the Latlng property so V8 data gets correctly parsed again. (when upgraded to Umbraco V9)

Added culture invariants to the Location.Parse so you do not get comma's instead of dots in your Lat/Lng.

Issue I had with upgrading from V8-> V9: https://github.com/ArnoldV/Our.Umbraco.GMaps/issues/91