### PR TITLE
Better V8 -> V9 compatibility

### DIFF
--- a/Our.Umbraco.GMaps.Core/Models/Address.cs
+++ b/Our.Umbraco.GMaps.Core/Models/Address.cs
@@ -5,6 +5,10 @@ namespace Our.Umbraco.GMaps.Models
 {
     public class Address
     {
+        [DataMember(Name = "latlng")]
+        [JsonProperty("latlng")]
+        public string Latlng { get; set; }
+        
         [DataMember(Name = "coordinates")]
         [JsonProperty("coordinates")]
         public Location Coordinates { get; set; }

--- a/Our.Umbraco.GMaps.Core/Models/Location.cs
+++ b/Our.Umbraco.GMaps.Core/Models/Location.cs
@@ -10,13 +10,13 @@ namespace Our.Umbraco.GMaps.Models
 
         [DataMember(Name = "lat")]
         [JsonProperty("lat")]
-        public double Latitude { get; set; }
+        public string Latitude { get; set; }
 
         [DataMember(Name = "lng")]
         [JsonProperty("lng")]
-        public double Longitude { get; set; }
+        public string Longitude { get; set; }
 
-        public bool IsEmpty => Latitude == 0 && Longitude == 0;
+         public bool IsEmpty => Latitude == string.Empty && Longitude == string.Empty;
 
         /// <summary>
         /// Parse the coordinates string.
@@ -27,17 +27,15 @@ namespace Our.Umbraco.GMaps.Models
         {
             if (!string.IsNullOrEmpty(latLng))
             {
-                var pair = latLng.Split(new[] { ',' }, StringSplitOptions.RemoveEmptyEntries);
+               var pair = latlng.Split(new[] { ',' }, StringSplitOptions.RemoveEmptyEntries);
                 if (pair.Length == 2)
                 {
-                    if (double.TryParse(pair[0], out double latitude) && double.TryParse(pair[1], out double longitude))
+                    return new Location
                     {
-                        return new Location
-                        {
-                            Latitude = latitude,
-                            Longitude = longitude
-                        };
-                    }
+                        Latitude = pair[0],
+                        Longitude = pair[1],
+                    };
+                    
                 }
             }
             return new Location();

--- a/Our.Umbraco.GMaps.Core/PropertyValueConverter/SingleMapPropertyValueConverter.cs
+++ b/Our.Umbraco.GMaps.Core/PropertyValueConverter/SingleMapPropertyValueConverter.cs
@@ -36,7 +36,13 @@ namespace Our.Umbraco.GMaps.PropertyValueConverter
 
             if (inter != null)
             {
+                inter = inter.ToString().Replace("google.maps.MapTypeId.", string.Empty);
+
                 model = JsonConvert.DeserializeObject<Map>(inter.ToString());
+                if(!string.IsNullOrWhiteSpace(model.Address?.Latlng))
+                {
+                    model.Address.Coordinates = Location.Parse(model.Address.Latlng);
+                }
             }
 
             if (model != null)


### PR DESCRIPTION
I've upgraded my site from V8 -> V9 whilst using this plugin. These changes would help the compatibility.

- Added 'old' latlng property so V8 data can still be used.
- Added a fallback for V8 data (so if V8 data isnt there, take the V9 data), used the currently unused Parser for this.
- Added a bugfix where V8 json data could have "google.maps.MapTypeId" in front of the maptype so enumparses would fail
- Changed double to string to avoid culture issues when parsing the doubles (in the NL the coords would be printed as "32,23131" instead of using a dot.) 

Regarding the last point, i'm fully aware a coordinate is actually a double, but for ease of use amongst all cultures, it's probably better to use it as a string so the coordinate always gets parsed correctly in the frontend.