### PR TITLE
Set runtime level to boot, avoiding crashes on upgrade

### DIFF
--- a/Our.Umbraco.GMaps.Core/Composing/Composer.cs
+++ b/Our.Umbraco.GMaps.Core/Composing/Composer.cs
@@ -14,7 +14,7 @@ namespace Our.Umbraco.GMaps.Core.Composing
 #if NET5_0_OR_GREATER
     public class Composer : IComposer
 #else
-    [RuntimeLevel(MinLevel = RuntimeLevel.Run)]
+    [RuntimeLevel(MinLevel = RuntimeLevel.Boot)]
     public class Composer : IUserComposer
 #endif
     {


### PR DESCRIPTION
Upgrading umbraco 8 will crash without this change. 
