### PR TITLE
Update SingleMapPropertyValueConverter.cs

### DIFF
--- a/Our.Umbraco.GMaps.Core/PropertyValueConverter/SingleMapPropertyValueConverter.cs
+++ b/Our.Umbraco.GMaps.Core/PropertyValueConverter/SingleMapPropertyValueConverter.cs
@@ -37,7 +37,7 @@ namespace Our.Umbraco.GMaps.PropertyValueConverter
             if (inter != null)
             {
                 // Handle pre v2.0.0 data.
-                inter = inter.ToString().Replace("google.maps.MapTypeId.", string.Empty);
+                inter = inter.ToString().ToLower().Replace("google.maps.maptypeid.", string.Empty);
                 bool legacyData = inter.ToString().Contains("latlng");
                 if (legacyData)
                 {


### PR DESCRIPTION
Sometimes you have google.maps.MapTypeId.ROADMAP, but also google.maps.maptypeid.ROADMAP, not sure why, perhaps legacy work? But I have them in my data ;-) This way it's always correct.