### PR TITLE
Add InvariantCulture to parsing of coordinates to ensure it work on non en-US culture. 

### DIFF
--- a/Our.Umbraco.GMaps.Core/Models/Location.cs
+++ b/Our.Umbraco.GMaps.Core/Models/Location.cs
@@ -1,5 +1,6 @@
 ﻿using Newtonsoft.Json;
 using System;
+using System.Globalization;
 using System.Runtime.Serialization;
 
 namespace Our.Umbraco.GMaps.Models
@@ -36,7 +37,7 @@ namespace Our.Umbraco.GMaps.Models
                 var pair = latLng.Split(new[] { ',' }, StringSplitOptions.RemoveEmptyEntries);
                 if (pair.Length == 2)
                 {
-                    if (double.TryParse(pair[0], out double latitude) && double.TryParse(pair[1], out double longitude))
+                    if (double.TryParse(pair[0], NumberStyles.Float | NumberStyles.AllowThousands, CultureInfo.InvariantCulture, out double latitude) && double.TryParse(pair[1], NumberStyles.Float | NumberStyles.AllowThousands, CultureInfo.InvariantCulture, out double longitude))
                     {
                         return new Location
                         {


### PR DESCRIPTION
Addresses #123

This PR ensures that InvariantCulture is used when parsing coordinates. Otherwise it will break on systems than use comma as decimal separator. 