### PR TITLE
Added fixes for 'legacy' map data

### DIFF
--- a/Our.Umbraco.GMaps.Core/Models/Legacy/LegacyMapConfig.cs
+++ b/Our.Umbraco.GMaps.Core/Models/Legacy/LegacyMapConfig.cs
@@ -6,5 +6,8 @@ namespace Our.Umbraco.GMaps.Models
     {
         [JsonProperty("mapcenter")]
         internal string MapCenter { get; set; }
+        
+        [JsonProperty("zoom")]
+        internal string Zoom { get; set; }
     }
 }

--- a/Our.Umbraco.GMaps.Core/PropertyValueConverter/SingleMapPropertyValueConverter.cs
+++ b/Our.Umbraco.GMaps.Core/PropertyValueConverter/SingleMapPropertyValueConverter.cs
@@ -51,6 +51,7 @@ namespace Our.Umbraco.GMaps.PropertyValueConverter
                     // Map the LatLng property.
                     model.Address.Coordinates = Location.Parse(intermediate.Address.LatLng);
                     model.MapConfig.CenterCoordinates = Location.Parse(intermediate.MapConfig.MapCenter);
+                    model.MapConfig.Zoom = string.IsNullOrEmpty(intermediate.MapConfig.Zoom) ? 17 : Convert.ToInt32(intermediate.MapConfig.Zoom);
                 }
                 else
                 {


### PR DESCRIPTION
So the introduction of the Zoom level as Int doesn't break legacy data