### PR TITLE
Changed GoogleMapsController to be a backoffice controller, and replaced all xcopy PreBuild events to use Microsoft's Copy instead for cross-platform support.

### DIFF
--- a/Our.Umbraco.GMaps.Core/Controllers/GoogleMapsController.cs
+++ b/Our.Umbraco.GMaps.Core/Controllers/GoogleMapsController.cs
@@ -1,7 +1,7 @@
 ﻿using Our.Umbraco.GMaps.Core.Config;
+using Umbraco.Cms.Web.BackOffice.Controllers;
 #if NET5_0_OR_GREATER
 using Microsoft.AspNetCore.Mvc;
-using Microsoft.Extensions.Configuration;
 using Umbraco.Cms.Web.Common.Attributes;
 using Umbraco.Cms.Web.Common.Controllers;
 #else
@@ -20,7 +20,7 @@ using Umbraco.Core.Mapping;
 namespace Our.Umbraco.GMaps.Core.Controllers
 {
     [PluginController(Constants.PluginName)]
-    public class GoogleMapsController : UmbracoApiController
+    public class GoogleMapsController : UmbracoAuthorizedJsonController
     {
         private readonly GoogleMapsConfig googleMapsConfig;
 

--- a/Our.Umbraco.GMaps.Core/Our.Umbraco.GMaps.Core.csproj
+++ b/Our.Umbraco.GMaps.Core/Our.Umbraco.GMaps.Core.csproj
@@ -53,24 +53,24 @@
 
 	<ItemGroup Condition="'$(TargetFramework)' == 'net472'">
 		<Reference Include="System.Web" />
-		<PackageReference Include="UmbracoCms.Core" Version="8.15.0" />
-		<PackageReference Include="UmbracoCms.Web" Version="8.15.0" />
+    <PackageReference Include="UmbracoCms.Core" Version="8.18.5" />
+    <PackageReference Include="UmbracoCms.Web" Version="8.18.5" />
 	</ItemGroup>
 
 	<ItemGroup Condition="'$(TargetFramework)' == 'net5.0'">
-		<PackageReference Include="Umbraco.Cms.Web.Common">
+    <PackageReference Include="Umbraco.Cms.Web.Backoffice">
 			<Version>9.0.0</Version>
 		</PackageReference>
 	</ItemGroup>
 
 	<ItemGroup Condition="'$(TargetFramework)' == 'net6.0'">
-		<PackageReference Include="Umbraco.Cms.Web.Common">
+    <PackageReference Include="Umbraco.Cms.Web.Backoffice">
 			<Version>9.0.0</Version>
 		</PackageReference>
 	</ItemGroup>
 
 	<ItemGroup Condition="'$(TargetFramework)' == 'net7.0'">
-		<PackageReference Include="Umbraco.Cms.Web.Common">
+    <PackageReference Include="Umbraco.Cms.Web.Backoffice">
 			<Version>9.0.0</Version>
 		</PackageReference>
 	</ItemGroup>

--- a/Our.Umbraco.GMaps.UmbracoV10/Our.Umbraco.GMaps.UmbracoV10.csproj
+++ b/Our.Umbraco.GMaps.UmbracoV10/Our.Umbraco.GMaps.UmbracoV10.csproj
@@ -33,7 +33,14 @@
     <RazorCompileOnBuild>false</RazorCompileOnBuild>
     <RazorCompileOnPublish>false</RazorCompileOnPublish>
   </PropertyGroup>
-	<Target Name="PreBuild" BeforeTargets="PreBuildEvent">
-		<Exec Command="xcopy $(SolutionDir)Our.Umbraco.GMaps\App_Plugins\Our.Umbraco.GMaps\*.* $(ProjectDir)App_Plugins\Our.Umbraco.GMaps\ /S /E /Y" />
-	</Target>
+  <Target Name="PreBuild" BeforeTargets="PreBuildEvent">
+    <ItemGroup>
+      <DataFiles Include="..\Our.Umbraco.GMaps\App_Plugins\Our.Umbraco.GMaps\**\*.*" />
+    </ItemGroup>
+
+    <Copy SourceFiles="@(DataFiles)"
+      DestinationFolder="$(ProjectDir)App_Plugins\Our.Umbraco.GMaps\%(RecursiveDir)"
+      SkipUnchangedFiles="true"
+       />
+  </Target>
 </Project>

--- a/Our.Umbraco.GMaps.UmbracoV10/Startup.cs
+++ b/Our.Umbraco.GMaps.UmbracoV10/Startup.cs
@@ -30,7 +30,7 @@ namespace Our.Umbraco.GMaps.UmbracoV10
         public void ConfigureServices(IServiceCollection services)
         {
             services.AddUmbraco(_env, _config)
-                .AddBackOffice()
+                .AddBackOffice() // this call registers the Our.Umbraco.GMaps.Core/Controllers/GoogleMapsController.cs
                 .AddWebsite()
                 .AddComposers()
                 .Build();

--- a/Our.Umbraco.GMaps.UmbracoV11/Startup.cs
+++ b/Our.Umbraco.GMaps.UmbracoV11/Startup.cs
@@ -30,7 +30,7 @@ namespace Our.Umbraco.GMaps.UmbracoV11
         public void ConfigureServices(IServiceCollection services)
         {
             services.AddUmbraco(_env, _config)
-                .AddBackOffice()
+                .AddBackOffice() // this call registers the Our.Umbraco.GMaps.Core/Controllers/GoogleMapsController.cs
                 .AddWebsite()
                 .AddComposers()
                 .Build();

--- a/Our.Umbraco.GMaps.UmbracoV9/Our.Umbraco.GMaps.UmbracoV9.csproj
+++ b/Our.Umbraco.GMaps.UmbracoV9/Our.Umbraco.GMaps.UmbracoV9.csproj
@@ -23,12 +23,12 @@
 
 
     <ItemGroup>
-      <None Include="umbraco\Data\Umbraco.mdf" />
-      <None Include="umbraco\Data\Umbraco_log.ldf" />
+        <None Include="umbraco\Data\Umbraco.mdf" />
+        <None Include="umbraco\Data\Umbraco_log.ldf" />
     </ItemGroup>
 
     <ItemGroup>
-      <ProjectReference Include="..\Our.Umbraco.GMaps.Core\Our.Umbraco.GMaps.Core.csproj" />
+        <ProjectReference Include="..\Our.Umbraco.GMaps.Core\Our.Umbraco.GMaps.Core.csproj" />
     </ItemGroup>
 
     <!-- Set this to true if ModelsBuilder mode is not InMemoryAuto-->
@@ -36,8 +36,14 @@
         <RazorCompileOnBuild>false</RazorCompileOnBuild>
         <RazorCompileOnPublish>false</RazorCompileOnPublish>
     </PropertyGroup>
-	<Target Name="PreBuild" BeforeTargets="PreBuildEvent">
-		<Exec Command="xcopy $(SolutionDir)Our.Umbraco.GMaps\App_Plugins\Our.Umbraco.GMaps\*.* $(ProjectDir)App_Plugins\Our.Umbraco.GMaps\ /S /E /Y" />
-	</Target>
+    <Target Name="PreBuild" BeforeTargets="PreBuildEvent">
+        <ItemGroup>
+            <DataFiles Include="..\Our.Umbraco.GMaps\App_Plugins\Our.Umbraco.GMaps\**\*.*" />
+        </ItemGroup>
 
+        <Copy SourceFiles="@(DataFiles)"
+            DestinationFolder="$(ProjectDir)App_Plugins\Our.Umbraco.GMaps\%(RecursiveDir)"
+            SkipUnchangedFiles="true"
+        />
+    </Target>
 </Project>

--- a/Our.Umbraco.GMaps.UmbracoV9/Startup.cs
+++ b/Our.Umbraco.GMaps.UmbracoV9/Startup.cs
@@ -41,7 +41,7 @@ namespace Our.Umbraco.GMaps.UmbracoV9
         {
 #pragma warning disable IDE0022 // Use expression body for methods
             services.AddUmbraco(_env, _config)
-                .AddBackOffice()
+                .AddBackOffice() // this call registers the Our.Umbraco.GMaps.Core/Controllers/GoogleMapsController.cs
                 .AddWebsite()
                 .AddComposers()
                 .Build();


### PR DESCRIPTION
This solves #136 and comes with the following changes:

- Bumps packages.
- Changes the package from `Umbraco.Cms.Web.Common` to `Umbraco.Cms.Web.Backoffice` in the `Our.Umbraco.GMaps.Core.csproj`. This includes the backoffice and frontend controller bases.
- Changed the `Our.Umbraco.GMaps.Core/Controllers/GoogleMapsController.cs` from an `UmbracoApiController` (Frontend Controller) to an `UmbracoAuthorizedJsonController` (Backoffice controller)
- Made all samples use Microsoft's `<Copy>` command instead of `xcopy`. This is cross-platform, and allows users on linux and mac to build the projects aswell.