### PR TITLE
Fixes #149 Address Values being lowercased

### DIFF
--- a/Our.Umbraco.GMaps.Core/PropertyValueConverter/SingleMapPropertyValueConverter.cs
+++ b/Our.Umbraco.GMaps.Core/PropertyValueConverter/SingleMapPropertyValueConverter.cs
@@ -32,12 +32,15 @@ namespace Our.Umbraco.GMaps.PropertyValueConverter
             Map model = null;
             if (inter != null)
             {
-                // Handle pre v2.0.0 data.
-                inter = inter.ToString().ToLower().Replace("google.maps.maptypeid.", string.Empty);
-                bool legacyData = inter.ToString().Contains("latlng");
+                var jsonString = inter.ToString();
+
+                // Handle pre v2.0.0 data (Removes the prefix 'google.maps.maptypeid.')
+                jsonString = jsonString.Replace("google.maps.maptypeid.", string.Empty, StringComparison.InvariantCultureIgnoreCase);
+
+                bool legacyData = jsonString.Contains("latlng", StringComparison.CurrentCultureIgnoreCase);
                 if (legacyData)
                 {
-                    var intermediate = JsonSerializer.Deserialize<LegacyMap>(inter.ToString());
+                    var intermediate = JsonSerializer.Deserialize<LegacyMap>(jsonString);
                     model = new Map
                     {
                         Address = intermediate.Address,
@@ -51,7 +54,7 @@ namespace Our.Umbraco.GMaps.PropertyValueConverter
                 }
                 else
                 {
-                    model = JsonSerializer.Deserialize<Map>(inter.ToString());
+                    model = JsonSerializer.Deserialize<Map>(jsonString);
                 }
             }
 


### PR DESCRIPTION
This fixes #149 Address Values being lowercased @robertjf 

The problem was that the entire JSON string was being lowercased to do some manipulation to the data, in doing so it lowercases the values in the JSON properties such as the Address.

### Before Fix
![image](https://github.com/ArnoldV/Our.Umbraco.GMaps/assets/1389894/25f1d720-5ff7-4728-b474-1bb33d1053a8)

![image](https://github.com/ArnoldV/Our.Umbraco.GMaps/assets/1389894/a49e6035-b9de-4868-aaae-45d1bb1286ad)


### After Fix
![image](https://github.com/ArnoldV/Our.Umbraco.GMaps/assets/1389894/0b630bb7-abb0-4920-bac6-d7474e6a0bc4)


## Test/Repro Notes
* Run V13 example site
* Use the textbox to enter in an address such as 'Umbraco' HQ's address
* Visit frontend and observer the address is lowercased
* Apply this PR/branch and re-run the site and view the frontend and the address data will not have been lowercased