### PR TITLE
Update LegacyMapConfig.cs to allow string or int zoom value

### DIFF
--- a/Our.Umbraco.GMaps.Core/Models/Legacy/LegacyMapConfig.cs
+++ b/Our.Umbraco.GMaps.Core/Models/Legacy/LegacyMapConfig.cs
@@ -9,8 +9,20 @@ namespace Our.Umbraco.GMaps.Models
         [JsonPropertyName("mapcenter")]
         public string MapCenter { get; set; }
 
+        [Newtonsoft.Json.JsonIgnore]
+        [System.Text.Json.Serialization.JsonIgnore]
+        public new string Zoom { get; set; }
+
         [JsonProperty("zoom")]
         [JsonPropertyName("zoom")]
-        public new string Zoom { get; set; }
+        public object _value
+        {
+            get
+            {
+                if (int.TryParse(Zoom, out var intValue)) return intValue;
+                return this.Zoom;
+            }
+            set { this.Zoom = value.ToString(); }
+        }
     }
 }


### PR DESCRIPTION
Proposed fix for int or string zoom values related issue https://github.com/ArnoldV/Our.Umbraco.GMaps/issues/171 