### PR TITLE
Implement the missing support for reading API key, default location and zoom from appsettings

### DIFF
--- a/Our.Umbraco.GMaps.Core/Controllers/GoogleMapsController.cs
+++ b/Our.Umbraco.GMaps.Core/Controllers/GoogleMapsController.cs
@@ -18,7 +18,7 @@ namespace Our.Umbraco.GMaps.Core.Controllers
             settings.OnChange(config => googleMapsConfig = config);
         }
 
-        [HttpGet]
+        [HttpGet("config")]
         public GoogleMaps GetSettings()
         {
             return googleMapsConfig;

--- a/Our.Umbraco.GMaps/src/gmaps-config.repository.ts
+++ b/Our.Umbraco.GMaps/src/gmaps-config.repository.ts
@@ -1,0 +1,21 @@
+import { UmbRepositoryBase } from "@umbraco-cms/backoffice/repository";
+import { tryExecuteAndNotify } from "@umbraco-cms/backoffice/resources";
+import { GMapsConfig } from "./types";
+import { OpenAPI } from '@umbraco-cms/backoffice/external/backend-api';
+
+export class GMapsConfigRepository extends UmbRepositoryBase {
+    public async getConfig(): Promise<GMapsConfig> {
+        const tokenPromise = (OpenAPI.TOKEN as any as () => Promise<string>);
+        const token = await tokenPromise();
+
+        const { data } = await tryExecuteAndNotify(this, fetch('/umbraco/management/api/v1/gmaps/config', {
+                method: 'GET',
+                headers: {
+                    'Authorization': 'Bearer ' + token
+                }
+            })
+        );
+
+        return await data?.json() as GMapsConfig;
+    }
+}

--- a/Our.Umbraco.GMaps/src/manifest.ts
+++ b/Our.Umbraco.GMaps/src/manifest.ts
@@ -52,7 +52,7 @@ export const manifests: Array<UmbExtensionManifest> = [
                 defaultData: [
                     {
                         "alias": "zoom",
-                        "value": 15
+                        "value": 17
                     },
                     {
                         "alias": "location",

--- a/Our.Umbraco.GMaps/src/types.ts
+++ b/Our.Umbraco.GMaps/src/types.ts
@@ -1,81 +1,87 @@
 export interface Map {
-    address: Address;
-    mapconfig: MapConfig;
+  address: Address;
+  mapconfig: MapConfig;
 }
 
 export interface Location {
-    lat: number;
-    lng: number;
+  lat: number;
+  lng: number;
 }
 
 export type MapType = "roadmap" | "satellite" | "hybrid" | "terrain" | "styled_map";
 
 export interface AddressBase {
-    full_address?: string;
-    streetNumber?: string;
-    street?: string;
-    postalcode?: string;
-    city?: string;
-    state?: string;
-    country?: string;
+  full_address?: string;
+  streetNumber?: string;
+  street?: string;
+  postalcode?: string;
+  city?: string;
+  state?: string;
+  country?: string;
 }
 
 export interface Address extends AddressBase {
-    coordinates?: Location;
+  coordinates?: Location;
 }
 
 type AddressFlags<Type> = {
-    [Property in keyof Type]: string[];
-  };
+  [Property in keyof Type]: string[];
+};
 
 export type AddressComponents = AddressFlags<AddressBase>
 
 
-interface MapConfig{
-    zoom?: number | string; //Can apparently be string in old values
+interface MapConfig {
+  zoom?: number | string; //Can apparently be string in old values
 
-    centerCoordinates?: Location;
+  centerCoordinates?: Location;
 
-    maptype?: MapType;
+  maptype?: MapType;
 }
 
 export function typedKeys<T extends object>(obj: T): Array<keyof T> {
-    return Object.keys(obj) as Array<keyof T>;
-  }
+  return Object.keys(obj) as Array<keyof T>;
+}
 
 
-  export interface SnazzyMapsResult {
-    pagination: Pagination;
-    styles: SnazzyMapsStyle[];
-  }
+export interface SnazzyMapsResult {
+  pagination: Pagination;
+  styles: SnazzyMapsStyle[];
+}
 
-  export interface Pagination {
-    currentPage: number;
-    pageSize: number;
-    totalItems: number;
-    totalPages: number;
-  }
+export interface Pagination {
+  currentPage: number;
+  pageSize: number;
+  totalItems: number;
+  totalPages: number;
+}
 
-  export interface SnazzyMapsStyle{
-    colors: string[];
-    createdBy: {
-        name: string;
-        url?: string;
-    };
-    createdOn?: string;
-    description?: string;
-    favorites: number;
-    id: number;
-    imageUrl: string;
-    json: string;
+export interface SnazzyMapsStyle {
+  colors: string[];
+  createdBy: {
     name: string;
-    tags: string[];
-    url: string;
-    views: number;
-  }
+    url?: string;
+  };
+  createdOn?: string;
+  description?: string;
+  favorites: number;
+  id: number;
+  imageUrl: string;
+  json: string;
+  name: string;
+  tags: string[];
+  url: string;
+  views: number;
+}
 
-  export interface SnazzyMapsValue {
-    apiKey?: string;
-    selectedstyle?: SnazzyMapsStyle;
-    customstyle?: string;
-  }
+export interface SnazzyMapsValue {
+  apiKey?: string;
+  selectedstyle?: SnazzyMapsStyle;
+  customstyle?: string;
+}
+
+export interface GMapsConfig {
+  apiKey?: string;
+  defaultLocation?: string;
+  zoomLevel?: number;
+}


### PR DESCRIPTION
In #190 I accidentally omitted support for the appsettings feature in v3. This PR addresses this and adds back this functionality.