### PR TITLE
Option to Hide the Map

### DIFF
--- a/Our.Umbraco.GMaps/Client/src/single-marker/manifest.ts
+++ b/Our.Umbraco.GMaps/Client/src/single-marker/manifest.ts
@@ -14,6 +14,12 @@ export const manifests: Array<UmbExtensionManifest> = [
             settings: {    
                 properties: [
                     {
+                        alias: "hideMap",
+                        label: "Hide Map",
+                        description: "Removes the map from display but maintains all functionality.",
+                        propertyEditorUiAlias: "Umb.PropertyEditorUi.Toggle"
+                    },
+                    {
                         alias: "apikey",
                         label: "Google API Key",
                         description: "Your Google Maps API Key",

--- a/Our.Umbraco.GMaps/Client/src/single-marker/single-marker-editor.element.ts
+++ b/Our.Umbraco.GMaps/Client/src/single-marker/single-marker-editor.element.ts
@@ -49,13 +49,13 @@ export default class GmapsPropertyEditorUiElement extends UmbElementMixin(LitEle
 
   #map?: google.maps.Map;
 
-
-
   @state()
   private _apiKey?: string;
 
   private _mapType: MapType = 'roadmap';
 
+  private _hideMap: boolean = false;
+  
   @state()
   private _zoomLevel: number = 17;
 
@@ -68,7 +68,6 @@ export default class GmapsPropertyEditorUiElement extends UmbElementMixin(LitEle
   @state()
   private _center?: Location;
 
-
   private _defaultLocation: Location = DEFAULT_LOCATION;
 
   private _autoCompleteSearchValue?: string;
@@ -77,6 +76,7 @@ export default class GmapsPropertyEditorUiElement extends UmbElementMixin(LitEle
   public set config(config: UmbPropertyEditorConfigCollection) {
     this._apiKey = config?.getValueByAlias<string>('apikey');
     this._mapType = config?.getValueByAlias<MapType>('maptype') || 'roadmap';
+    this._hideMap = config?.getValueByAlias<boolean>('hideMap') || false;
     this._zoomLevel = config?.getValueByAlias<number>('zoom') || 17;
 
     const location = config?.getValueByAlias<number>('location')
@@ -401,16 +401,16 @@ export default class GmapsPropertyEditorUiElement extends UmbElementMixin(LitEle
               <uui-loader style='color: color: #006eff'></uui-loader>
             ` : nothing}
 
-            <div id='map'></div>
+            <div id='map' style="${this._hideMap ? 'display:none;' : ''}"></div>
 
             ${this._error ? html`
               <div class='error'>${this._error}</div>
             ` : nothing}
 
-            <div class='coordinates'>
-                    <div>Pin: ${this.value?.address.coordinates?.lat},${this.value?.address.coordinates?.lng}</div>
-                    <div>Zoom: ${this.value?.mapconfig.zoom}</div>
-                    <div>Center: ${this._center?.lat},${this._center?.lng}</div>
+            <div class='coordinates' style="${this._hideMap ? 'display:none;' : ''}">
+                <div>Pin: ${this.value?.address.coordinates?.lat},${this.value?.address.coordinates?.lng}</div>
+                <div>Zoom: ${this.value?.mapconfig.zoom}</div>
+                <div>Center: ${this._center?.lat},${this._center?.lng}</div>
             </div>
         `;
   }

--- a/Our.Umbraco.GMaps/Client/src/types.ts
+++ b/Our.Umbraco.GMaps/Client/src/types.ts
@@ -84,4 +84,5 @@ export interface GMapsConfig {
   apiKey?: string;
   defaultLocation?: string;
   zoomLevel?: number;
+  hideMap?: boolean;
 }


### PR DESCRIPTION
> This is a draft pull request.

This PR addresses the issue raised in #181. 

This property editor offers useful features like address completion and geolocation data. However, my client prefers to hide the map completely during editing. Therefore, we've customized the package to include a toggle that controls whether the map is displayed.

The strategy was to avoid altering the core logic of your property editor and only control the visibility of the map.

<img width="1199" height="875" alt="image" src="https://github.com/user-attachments/assets/2a99078b-3a19-4ad7-9d60-a7b6e14a5673" />

<img width="1382" height="986" alt="image" src="https://github.com/user-attachments/assets/bbfcdeb9-bdbf-442d-ab51-ffee831a0247" />

Once the scope of this PR is accepted, I am happy to make further changes until the work is approved. Please share your thoughts. 

Best regards,