### PR TITLE
fix: seed _address and _location from stored value on load

### DIFF
--- a/Our.Umbraco.GMaps/Client/src/single-marker/single-marker-editor.element.ts
+++ b/Our.Umbraco.GMaps/Client/src/single-marker/single-marker-editor.element.ts
@@ -111,6 +111,17 @@ export default class GmapsPropertyEditorUiElement extends UmbElementMixin(LitEle
   }
 
   async firstUpdated() {
+    // Seed _address and _location from the stored value so that any map
+    // interaction (drag, zoom, pan) that triggers setValue() before the user
+    // searches a new address preserves the existing address components.
+    // Without this, _address is undefined on load and spreading it in
+    // setValue() silently replaces the full address object with only { coordinates }.
+    if (this.value?.address) {
+      const { coordinates, ...rest } = this.value.address;
+      this._address ??= rest;
+      this._location ??= coordinates;
+    }
+
     if (this.#settingsContext) {
       const serverConfig = await this.#settingsContext.getSettings();
       if (serverConfig) {


### PR DESCRIPTION
Fixes #232

## Root cause

`_address` and `_location` are reactive state properties that are only ever written to from two places:

- `updateMarkerAddress()` — called after the Autocomplete `place_changed` event
- `dragend()` — updates `_location` only

Neither seeds from the existing stored value when the element first loads. `setValue()` (triggered by every map interaction — drag, zoom, pan) builds the outgoing value by spreading `_address`:

```ts
this.value = {
  address: {
    ...this._address,   // undefined on load → spreads as {} → address fields lost
    coordinates: { ... }
  },
  ...
}
```

So the first map interaction after page load silently discards all address fields (street, city, state, etc.) from the UI value. Reloading restores them because the database was not saved — but saving after interacting would permanently destroy the address data.

## Fix

Seed `_address` and `_location` from `this.value` at the top of `firstUpdated()`, before the map and its event listeners are initialised. The `??=` operator ensures we only write if the properties are still undefined, making the fix safe if `firstUpdated` were ever called more than once.

## Testing

1. Open a document with an existing saved GMaps single-marker value
2. Pan or zoom the map without searching a new address
3. Confirm the address fields in the UI are preserved (previously they were cleared to coordinates-only after any interaction)