### PR TITLE
Add intent for drag/scroll... ctrl+ scroll/drag, so that unintentional map interactions are avoided

### DIFF
--- a/Our.Umbraco.GMaps/Client/src/single-marker/single-marker-editor.element.ts
+++ b/Our.Umbraco.GMaps/Client/src/single-marker/single-marker-editor.element.ts
@@ -516,22 +516,16 @@ export default class GmapsPropertyEditorUiElement extends UmbElementMixin(LitEle
   }
 
   #setupCtrlInteractions(map: google.maps.Map) {
-    // 1. Create the native control container for the hint banner
-    const controlDiv = document.createElement('div');
-    controlDiv.style.padding = '10px';
-
-    const hintChild = document.createElement('div');
-    hintChild.className = 'ctrl-drag-banner';
-    hintChild.innerHTML = 'Use Ctrl + drag to move the map';
-    controlDiv.appendChild(hintChild);
+    const overlay = this.shadowRoot?.getElementById('ctrlScrollOverlay');
+    if (!overlay) return;
 
     let timeout: number | undefined;
 
     const showHint = () => {
-      hintChild.classList.add('visible');
+      overlay.classList.add('visible');
       globalThis.clearTimeout(timeout);
       timeout = globalThis.setTimeout(() => {
-        hintChild.classList.remove('visible');
+        overlay.classList.remove('visible');
       }, 2000);
     };
 
@@ -542,7 +536,7 @@ export default class GmapsPropertyEditorUiElement extends UmbElementMixin(LitEle
     const handleKeyDown = (e: KeyboardEvent) => {
       if (e.key === 'Control' || e.key === 'Meta') {
         isCtrlPressed = true;
-        hintChild.classList.remove('visible');
+        overlay.classList.remove('visible');
       }
     };
 
@@ -567,9 +561,6 @@ export default class GmapsPropertyEditorUiElement extends UmbElementMixin(LitEle
         showHint();
       }
     });
-
-    // 2. Push the hint into Google Maps' native control layout pipeline
-    map.controls[google.maps.ControlPosition.TOP_CENTER].push(controlDiv);
   }
 
   setValue() {
@@ -626,7 +617,10 @@ export default class GmapsPropertyEditorUiElement extends UmbElementMixin(LitEle
               <uui-loader style='color: color: #006eff'></uui-loader>
             ` : nothing}
 
-            <div id='map' style="${this._hideMap ? 'display:none;' : ''}"></div>
+            <div class='map-container' style="${this._hideMap ? 'display:none;' : ''}">
+                <div id='map'></div>
+                <div class='ctrl-scroll-overlay' id='ctrlScrollOverlay'>Use ctrl + drag to pan the map</div>
+            </div>
 
             ${this._error ? html`
               <div class='error'>${this._error}</div>
@@ -643,10 +637,42 @@ export default class GmapsPropertyEditorUiElement extends UmbElementMixin(LitEle
   static override readonly styles = [
     UmbTextStyles,
     css`
-      #map{
-        height: 500px;
+      .map-container {
+        position: relative;
         width: 100%;
         margin-top: 1em;
+      }
+
+      #map {
+        height: 500px;
+        width: 100%;
+      }
+
+      .ctrl-scroll-overlay {
+        position: absolute;
+        top: 0;
+        left: 0;
+        width: 100%;
+        height: 100%;
+        background-color: rgba(0, 0, 0, 0.55);
+        color: white;
+        display: flex;
+        justify-content: center;
+        align-items: center;
+        font-family: Roboto, Arial, sans-serif;
+        font-size: 1.4rem;
+        font-weight: 500;
+        text-shadow: 0 1px 3px rgba(0, 0, 0, 0.6);
+        z-index: 1000;
+        pointer-events: none;
+        visibility: hidden;
+        opacity: 0;
+        transition: visibility 0.3s, opacity 0.3s ease-in-out;
+      }
+
+      .ctrl-scroll-overlay.visible {
+        visibility: visible;
+        opacity: 1;
       }
 
       .coordinates{
@@ -697,27 +723,6 @@ export default class GmapsPropertyEditorUiElement extends UmbElementMixin(LitEle
       .pin-icon {
         flex: 0 0 auto;
         color: #d64545;
-      }
-
-      .ctrl-drag-banner {
-        visibility: hidden;
-        opacity: 0;
-        background: rgba(0, 0, 0, 0.75);
-        color: #fff;
-        padding: 6px 12px;
-        border-radius: 4px;
-        font-size: 0.85rem;
-        font-weight: 500;
-        box-shadow: 0 2px 6px rgba(0,0,0,0.3);
-        transform: translateY(-4px);
-        transition: opacity 0.2s ease-in-out, transform 0.2s ease-in-out, visibility 0.2s;
-        pointer-events: none;
-      }
-
-      .ctrl-drag-banner.visible {
-        visibility: visible;
-        opacity: 1;
-        transform: translateY(0);
       }
       `,
   ];

--- a/Our.Umbraco.GMaps/Client/src/single-marker/single-marker-editor.element.ts
+++ b/Our.Umbraco.GMaps/Client/src/single-marker/single-marker-editor.element.ts
@@ -206,7 +206,10 @@ export default class GmapsPropertyEditorUiElement extends UmbElementMixin(LitEle
       zoom: this.getAsNumber(this.value.mapconfig.zoom) ?? this._zoomLevel,
       mapTypeId: this._mapType.toString().toLowerCase(),
       mapId: '4504f8b37365c3d0',
+      gestureHandling: "cooperative",
     });
+
+    this.#setupCtrlInteractions(map);
 
     this.marker = new AdvancedMarkerElement({
       map,
@@ -512,6 +515,63 @@ export default class GmapsPropertyEditorUiElement extends UmbElementMixin(LitEle
     }
   }
 
+  #setupCtrlInteractions(map: google.maps.Map) {
+    // 1. Create the native control container for the hint banner
+    const controlDiv = document.createElement('div');
+    controlDiv.style.padding = '10px';
+
+    const hintChild = document.createElement('div');
+    hintChild.className = 'ctrl-drag-banner';
+    hintChild.innerHTML = 'Use Ctrl + drag to move the map';
+    controlDiv.appendChild(hintChild);
+
+    let timeout: number | undefined;
+
+    const showHint = () => {
+      hintChild.classList.add('visible');
+      globalThis.clearTimeout(timeout);
+      timeout = globalThis.setTimeout(() => {
+        hintChild.classList.remove('visible');
+      }, 2000);
+    };
+
+    let isCtrlPressed = false;
+    let lastCenter: google.maps.LatLng | null | undefined = null;
+
+    // Track global modifier keys
+    const handleKeyDown = (e: KeyboardEvent) => {
+      if (e.key === 'Control' || e.key === 'Meta') {
+        isCtrlPressed = true;
+        hintChild.classList.remove('visible');
+      }
+    };
+
+    const handleKeyUp = (e: KeyboardEvent) => {
+      if (e.key === 'Control' || e.key === 'Meta') {
+        isCtrlPressed = false;
+      }
+    };
+
+    globalThis.addEventListener('keydown', handleKeyDown);
+    globalThis.addEventListener('keyup', handleKeyUp);
+
+    // Save center right before any drag interaction begins
+    map.addListener('dragstart', () => {
+      lastCenter = map.getCenter() ?? null;
+    });
+
+    // If a drag happens without Ctrl/Cmd, instantly cancel it by snapping back & showing the hint
+    map.addListener('drag', () => {
+      if (!isCtrlPressed && lastCenter) {
+        map.setCenter(lastCenter);
+        showHint();
+      }
+    });
+
+    // 2. Push the hint into Google Maps' native control layout pipeline
+    map.controls[google.maps.ControlPosition.TOP_CENTER].push(controlDiv);
+  }
+
   setValue() {
     if (this.#clearValue) return;
 
@@ -637,6 +697,27 @@ export default class GmapsPropertyEditorUiElement extends UmbElementMixin(LitEle
       .pin-icon {
         flex: 0 0 auto;
         color: #d64545;
+      }
+
+      .ctrl-drag-banner {
+        visibility: hidden;
+        opacity: 0;
+        background: rgba(0, 0, 0, 0.75);
+        color: #fff;
+        padding: 6px 12px;
+        border-radius: 4px;
+        font-size: 0.85rem;
+        font-weight: 500;
+        box-shadow: 0 2px 6px rgba(0,0,0,0.3);
+        transform: translateY(-4px);
+        transition: opacity 0.2s ease-in-out, transform 0.2s ease-in-out, visibility 0.2s;
+        pointer-events: none;
+      }
+
+      .ctrl-drag-banner.visible {
+        visibility: visible;
+        opacity: 1;
+        transform: translateY(0);
       }
       `,
   ];


### PR DESCRIPTION
We've been having issues in the back office where editors are unintentionally interacting with maps (either scroll or pan) and without realising it, publishing their other intended changes. Which brings with it unintended map changes.

Google does have inbuilt `gestureHandling: "cooperative",` which does for the scroll intent.. (ctrl + scroll required)

But there isn't anything for drag/pan.  So here's something that implements a companion overlay to instruct `ctrl + drag` is required.


PS this was particular seen in 17.0.0 as editors were unintentionally panning the map, and on save that was resetting the pin location back to default pin settings for some reason, though that now seems fixed by 17.01 or 17.1.0 updates