### PR TITLE
Add a reset property action.

### DIFF
--- a/Our.Umbraco.GMaps/Client/src/single-marker/actions/clear/manifest.ts
+++ b/Our.Umbraco.GMaps/Client/src/single-marker/actions/clear/manifest.ts
@@ -7,6 +7,7 @@ export const manifests: Array<UmbExtensionManifest> =
     kind: 'default',
     alias: 'GMaps.PropertyAction.ClearMarker',
     name: 'GMaps Clear Markers Property Action',
+    weight: 20,
     forPropertyEditorUis: ["GMaps.PropertyEditorUi.SingleMap"],
     conditions: [
 			{

--- a/Our.Umbraco.GMaps/Client/src/single-marker/actions/reset/manifest.ts
+++ b/Our.Umbraco.GMaps/Client/src/single-marker/actions/reset/manifest.ts
@@ -1,0 +1,22 @@
+import { UMB_PROPERTY_HAS_VALUE_CONDITION_ALIAS } from '@umbraco-cms/backoffice/property';
+
+export const manifests: Array<UmbExtensionManifest> = [
+  {
+    type: 'propertyAction',
+    kind: 'default',
+    alias: 'GMaps.PropertyAction.ResetView',
+    name: 'GMaps Reset View Property Action',
+    weight: 10,
+    forPropertyEditorUis: ["GMaps.PropertyEditorUi.SingleMap"],
+    conditions: [
+      {
+        alias: UMB_PROPERTY_HAS_VALUE_CONDITION_ALIAS,
+      },
+    ],
+    api: () => import('./reset-property-action.api.js'),
+    meta: {
+      icon: 'icon-target', // Icon to display in the UI
+      label: 'Reset Map View', // Label shown to editors
+    },
+  },
+];

--- a/Our.Umbraco.GMaps/Client/src/single-marker/actions/reset/reset-property-action.api.ts
+++ b/Our.Umbraco.GMaps/Client/src/single-marker/actions/reset/reset-property-action.api.ts
@@ -1,0 +1,31 @@
+import { UmbPropertyActionArgs, UmbPropertyActionBase } from '@umbraco-cms/backoffice/property-action';
+import { UMB_PROPERTY_CONTEXT } from '@umbraco-cms/backoffice/property';
+import { UmbControllerHost } from '@umbraco-cms/backoffice/controller-api';
+import type GmapsPropertyEditorUiElement from '../../single-marker-editor.element.js';
+
+export class GMapsPropertyActionReset extends UmbPropertyActionBase {
+	#init: Promise<unknown>;
+	#propertyContext?: typeof UMB_PROPERTY_CONTEXT.TYPE;
+
+	constructor(host: UmbControllerHost, args: UmbPropertyActionArgs<never>) {
+		super(host, args);
+
+		this.#init = Promise.all([
+			this.consumeContext(UMB_PROPERTY_CONTEXT, (context) => {
+				this.#propertyContext = context;
+			}).asPromise({ preventTimeout: true }),
+		]);
+	}
+
+	async execute() {
+		await this.#init;
+		if (!this.#propertyContext) throw new Error('Property context not found');
+
+		const editor = this.#propertyContext.getEditor() as GmapsPropertyEditorUiElement | undefined;
+		if (editor && typeof editor.resetView === 'function') {
+			editor.resetView();
+		}
+	}
+}
+
+export { GMapsPropertyActionReset as api };

--- a/Our.Umbraco.GMaps/Client/src/single-marker/manifest.ts
+++ b/Our.Umbraco.GMaps/Client/src/single-marker/manifest.ts
@@ -1,4 +1,5 @@
-import { manifests as actions } from './actions/clear/manifest';
+import { manifests as clearActions } from './actions/clear/manifest';
+import { manifests as resetActions } from './actions/reset/manifest';
 
 export const manifests: Array<UmbExtensionManifest> = [
     {
@@ -78,5 +79,6 @@ export const manifests: Array<UmbExtensionManifest> = [
         api: () => import('./single-marker-property-value-preset.js'),
         forPropertyEditorUiAlias: "GMaps.PropertyEditorUi.SingleMap",
     },
-    ...actions,
-]
+    ...clearActions,
+    ...resetActions,
+]

--- a/Our.Umbraco.GMaps/Client/src/single-marker/single-marker-editor.element.ts
+++ b/Our.Umbraco.GMaps/Client/src/single-marker/single-marker-editor.element.ts
@@ -22,6 +22,7 @@ export default class GmapsPropertyEditorUiElement extends UmbElementMixin(LitEle
   // track that both have been received and defer map initialisation until then
   // (see #tryInitialize) so datatype config (api key, map type, zoom, default
   // location) is always applied.
+  #initialValue?: Map
   #valueReceived = false
   #configReceived = false
   #initialized = false
@@ -29,7 +30,11 @@ export default class GmapsPropertyEditorUiElement extends UmbElementMixin(LitEle
   @property({ type: Object })
   public set value(val: Map | undefined) {
     this.#valueReceived = true
+    if (!this.#initialValue && val) {
+      this.#initialValue = structuredClone(val);
+    }
     if (val === undefined) {
+      this.#initialValue = undefined;
       this.#clearValue = true
       if (this.marker) {
         this.marker.position = { lat: this._defaultLocation.lat, lng: this._defaultLocation.lng ?? 0 }
@@ -318,6 +323,71 @@ export default class GmapsPropertyEditorUiElement extends UmbElementMixin(LitEle
     this.#map = map;
     this._loading = false;
   }
+
+  resetView() {
+    if (!this.#map) return;
+
+    const savedPinCoordinates = this.#initialValue?.address?.coordinates;
+    const targetCenter =
+      this.#initialValue?.mapconfig?.centerCoordinates ??
+      savedPinCoordinates ??
+      this._defaultLocation;
+
+    const targetZoom =
+      this.getAsNumber(this.#initialValue?.mapconfig?.zoom) ??
+      this._zoomLevel ??
+      17;
+
+    // Restore saved address, friendly name, location, and search input text
+    if (this.#initialValue?.address) {
+      const { coordinates, ...rest } = this.#initialValue.address;
+      this._address = structuredClone(rest);
+      this._location = coordinates ? { ...coordinates } : undefined;
+      this._friendlyName = this.#initialValue.address.friendlyName;
+      if (this.#initialValue.address.full_address) {
+        this._autoCompleteSearchValue = this.#initialValue.address.full_address;
+      } else if (coordinates) {
+        this._autoCompleteSearchValue = this.formatCoordinates(coordinates);
+      }
+    } else {
+      this._address = undefined;
+      this._location = undefined;
+      this._friendlyName = undefined;
+      this._autoCompleteSearchValue = undefined;
+    }
+
+    // Reset marker position to saved pin coordinates (or default location)
+    if (this.marker) {
+      const markerLat = this.getAsNumber(savedPinCoordinates?.lat ?? this._defaultLocation.lat) ?? 0;
+      const markerLng = this.getAsNumber(savedPinCoordinates?.lng ?? this._defaultLocation.lng) ?? 0;
+      this.marker.position = { lat: markerLat, lng: markerLng };
+    }
+
+    // Reset map view center to original center coordinates
+    if (targetCenter) {
+      const lat = this.getAsNumber(targetCenter.lat);
+      const lng = this.getAsNumber(targetCenter.lng);
+      if (lat !== undefined && lng !== undefined && !Number.isNaN(lat) && !Number.isNaN(lng)) {
+        this.#map.setCenter({ lat, lng });
+      }
+    }
+
+    // Reset map view zoom
+    if (targetZoom !== undefined && !Number.isNaN(targetZoom)) {
+      this.#map.setZoom(targetZoom);
+    }
+
+    // Sync state and notify Umbraco
+    const centerLat = this.getAsNumber(targetCenter?.lat ?? this._defaultLocation.lat);
+    const centerLng = this.getAsNumber(targetCenter?.lng ?? this._defaultLocation.lng);
+    if (centerLat !== undefined && centerLng !== undefined) {
+      this._center = { lat: centerLat, lng: centerLng };
+    }
+    this._zoomLevel = targetZoom;
+    this.setValue();
+  }
+
+
 
   // Places the marker at raw coordinates typed into the search box and, best
   // effort, reverse geocodes them so the saved value carries a readable address


### PR DESCRIPTION
Alternative to intent with ctrl+ drag/scroll at least if we noticed we altered something we can then reset the map without loosing any other changes we made with a page refresh...